### PR TITLE
Make service definition lookup better respect cmdline args

### DIFF
--- a/src/woorl.erl
+++ b/src/woorl.erl
@@ -85,7 +85,7 @@ parse_options(Args) ->
 
 prepare_options(Opts, Args) ->
     Url = require_option(url, Opts),
-    SchemaPaths = lists:usort(require_options(schema, Opts)),
+    SchemaPaths = require_options(schema, Opts), % we deliberately do not care about duplicates here
     ServiceName = require_option(service, Opts),
     FunctionName = require_option(function, Opts),
     Modules = prepare_schemas(SchemaPaths, Opts),
@@ -140,7 +140,7 @@ compile_artifact(Path) ->
 
 filter_service_modules(Modules, SchemaPaths) ->
     SchemaNames = [list_to_binary(filename:basename(SP, ".thrift")) || SP <- SchemaPaths],
-    [M || M <- Modules, binary:match(atom_to_binary(M, utf8), SchemaNames) /= nomatch].
+    [M || SN <- SchemaNames, M <- Modules, binary:match(atom_to_binary(M, utf8), SN) /= nomatch].
 
 detect_service_function(ServiceName, FunctionName, Modules) ->
     Service = list_to_atom(ServiceName),


### PR DESCRIPTION
Сейчас мы можем огрести ситуацию, когда подходящий по названию трифт-сервис берётся из _первого подошедшего_<sup>чаще всего, в лексикографическом порядке</sup> сгенерированного модуля, что приводит к неожиданному поведению в ситуациях, когда в репозитории много одноимённых трифт-сервисов в разных файлах, связанных инклюдами.

С этим патчем мы будем брать первый подходящий модуль среди тех, которые указаны в аргументе командной строки `schema`.
