### PR TITLE
Add woorl-json mode just for thrift encode / decode

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -64,4 +64,4 @@
     {plt_apps, all_deps}
 ]}.
 
-{escript_emu_args, "%%! +sbtu +A0 -noshell -boot start_clean\n"}.
+{escript_emu_args, "%%! +sbtu +A0 -noshell -boot start_clean -escript main woorl\n"}.

--- a/src/woorl.erl
+++ b/src/woorl.erl
@@ -71,15 +71,13 @@ report_usage(woorl) ->
             "If it starts with `@' symbol then the rest will be interpreted as a name of a file containing JSON value."
         }]
     ),
-    io:format(standard_error, "~s", [[
-        "Exit status:\n",
-        [format_exit_code(?SUCCESS)       , $\t, "Call succeeded"            "\n"],
-        [format_exit_code(?EXCEPTION)     , $\t, "Call raised an exception"  "\n"],
-        [format_exit_code(?WOODY_ERROR)   , $\t, "Call failed"               "\n"],
-        [format_exit_code(?COMPILE_ERROR) , $\t, "Schema compilation failed" "\n"],
-        [format_exit_code(?INPUT_ERROR)   , $\t, "Input error"               "\n"],
-        "\n"
-    ]]);
+    report_exit_codes([
+        ?SUCCESS,
+        ?EXCEPTION,
+        ?WOODY_ERROR,
+        ?COMPILE_ERROR,
+        ?INPUT_ERROR
+    ]);
 
 report_usage(woorl_json) ->
     print_version(),
@@ -87,19 +85,29 @@ report_usage(woorl_json) ->
         get_options_spec(woorl_json), "woorl-json",
         []
     ),
-    io:format(standard_error, "~s", [[
-        "Exit status:\n",
-        [format_exit_code(?SUCCESS)       , $\t, "Succeeded"                 "\n"],
-        [format_exit_code(?COMPILE_ERROR) , $\t, "Schema compilation failed" "\n"],
-        [format_exit_code(?INPUT_ERROR)   , $\t, "Input error"               "\n"],
-        "\n"
-    ]]).
+    report_exit_codes([
+        ?SUCCESS,
+        ?COMPILE_ERROR,
+        ?INPUT_ERROR
+    ]).
 
 print_version() ->
     {ok, Vsn} = application:get_key(?MODULE, vsn),
     io:format(standard_error, "~s ~s~n~n", [?MODULE_STRING, Vsn]).
 
-format_exit_code(C) ->
+report_exit_codes(Codes) ->
+    io:format(standard_error, "~s", [[
+        "Exit status:\n" |
+        [[pad_exit_code(Code), $\t, format_exit_code(Code), $\n] || Code <- Codes]
+    ]]).
+
+format_exit_code(?SUCCESS)       -> "Call succeeded";
+format_exit_code(?EXCEPTION)     -> "Call raised an exception";
+format_exit_code(?WOODY_ERROR)   -> "Call failed";
+format_exit_code(?COMPILE_ERROR) -> "Schema compilation failed";
+format_exit_code(?INPUT_ERROR)   -> "Input error".
+
+pad_exit_code(C) ->
     genlib_string:pad_left(integer_to_binary(C), $\s, 5).
 
 get_default_reqid() ->

--- a/src/woorl_schema.erl
+++ b/src/woorl_schema.erl
@@ -1,0 +1,78 @@
+-module(woorl_schema).
+
+-export([prepare/2]).
+
+-type opts() :: [
+    {tempdir, file:filename_all()}
+].
+
+-spec prepare([file:filename_all()], opts()) ->
+    {ok, [module()]} | {error, _Reason}.
+prepare(SchemaPaths, Opts) ->
+    try
+        _ = assert_paths(SchemaPaths),
+        TempPath = make_temp_dir(woorl_utils:temp_dir(genlib_opts:get(tempdir, Opts), "woorl-gen")),
+        Modules = lists:foldl(
+            fun (SchemaPath, Acc) -> prepare_schema(SchemaPath, TempPath) ++ Acc end,
+            [],
+            SchemaPaths
+        ),
+        _ = clean_temp_dir(TempPath),
+        {ok, Modules}
+    catch
+        throw:{?MODULE, Reason} ->
+            {error, Reason}
+    end.
+
+assert_paths(Paths) ->
+    [throw({?MODULE, {invalid_file, P}}) || P <- Paths, not filelib:is_regular(P)].
+
+prepare_schema(SchemaPath, TempPath) ->
+    prepare_schema(SchemaPath, filename:extension(SchemaPath), TempPath).
+
+prepare_schema(SchemaPath, ".thrift", TempPath) ->
+    ErlFilesWas = filelib:wildcard("*.erl", TempPath),
+    ok = generate_schema(SchemaPath, TempPath),
+    ErlFilesNew = filelib:wildcard("*.erl", TempPath) -- ErlFilesWas,
+    ErlPaths = [filename:join(TempPath, P) || P <- ErlFilesNew],
+    Modules0 = compile_artifacts(ErlPaths),
+    Modules1 = filter_required_modules(Modules0, SchemaPath),
+    Modules1;
+prepare_schema(SchemaPath, ".beam", _) ->
+    true = code:add_pathz(filename:dirname(SchemaPath)),
+    ModuleName = list_to_atom(filename:basename(SchemaPath, ".beam")),
+    {module, Module} = code:load_file(ModuleName),
+    [Module].
+
+make_temp_dir(Path) ->
+    case file:make_dir(Path) of
+        ok ->
+            Path;
+        {error, Reason} ->
+            throw({?MODULE, {invalid_temp_dir, Path, Reason}})
+    end.
+
+clean_temp_dir(Path) ->
+    woorl_utils:sh("rm -rf " ++ Path).
+
+generate_schema(Path, TempPath) ->
+    CmdArgs = ["-r", "-out", TempPath, "--gen", "erlang:scoped_typenames", Path],
+    Command = string:join(["thrift" | CmdArgs], " "),
+    case woorl_utils:sh(Command) of
+        {ok, _} ->
+            ok;
+        {error, {Code, Output}} ->
+            throw({?MODULE, {compilation_failed, Path, Code, Output}})
+    end.
+
+compile_artifacts(Paths) ->
+    [compile_artifact(P) || P <- Paths].
+
+compile_artifact(Path) ->
+    {ok, Module, Bin} = compile:file(Path, [binary, debug_info]),
+    {module, Module} = code:load_binary(Module, Path, Bin),
+    Module.
+
+filter_required_modules(Modules, SchemaPath) ->
+    SchemaName = list_to_binary(filename:basename(SchemaPath, ".thrift")),
+    [M || M <- Modules, binary:match(atom_to_binary(M, utf8), SchemaName) /= nomatch].

--- a/src/woorl_schema.erl
+++ b/src/woorl_schema.erl
@@ -39,6 +39,9 @@ prepare_schema(SchemaPath, ".thrift", TempPath) ->
     Modules1 = filter_required_modules(Modules0, SchemaPath),
     Modules1;
 prepare_schema(SchemaPath, ".beam", _) ->
+    % TODO
+    % This is undocumented hack for now, you can pass compiled .beam files in as schemas so that
+    % woorl could skip schema compiling step altogether. All in the name of speed.
     true = code:add_pathz(filename:dirname(SchemaPath)),
     ModuleName = list_to_atom(filename:basename(SchemaPath, ".beam")),
     {module, Module} = code:load_file(ModuleName),

--- a/src/woorl_utils.erl
+++ b/src/woorl_utils.erl
@@ -5,6 +5,8 @@
 
 -export([sh/1]).
 
+-export([read_input/0]).
+
 %%
 
 -spec unique_string(binary()) -> binary().
@@ -51,4 +53,20 @@ sh_loop(Port, Acc) ->
                 {Port, {exit_status, Rc}} ->
                     {error, {Rc, Data}}
             end
+    end.
+
+-define(BLK_SIZE, 16384).
+
+-spec read_input() ->
+    binary().
+read_input() ->
+    ok = io:setopts(standard_io, [binary]),
+    string:chomp(read_input(<<>>)).
+
+read_input(Acc) ->
+    case file:read(standard_io, ?BLK_SIZE) of
+        {ok, Data} ->
+            read_input(<<Acc/bytes, Data/bytes>>);
+        eof ->
+            Acc
     end.


### PR DESCRIPTION
This mode activates _only_ if script being executed has `woorl-json` as the basename, busybox-style. It's not perfect because it's not discoverable, though hypothetical package manager would have taken care of it, e.g. through symlinking upon install. Yet I'm open to other suggestions.